### PR TITLE
Add Preferences menu: autostart, LAN, API key, model management

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,7 +33,9 @@
 - PRs: clear description, scope of change, testing steps (`xcodebuild build`, `./test_api.sh` results), linked issues, and screenshots if UI/menu-bar behavior changes.
 
 ## Security & Configuration Tips
-- Default port is `12017`; avoid exposing beyond localhost in development.
+- Default port is `12017`. The server binds to `localhost` by default; users can opt in to `0.0.0.0` via the "Expose on Local Network" menu bar toggle.
+- LAN requests may optionally require a bearer token via the "Require API Key" toggle. Tokens live in `APIKeyStore` (Keychain-backed, service = bundle id, account = `whisper-api-key`). `APIKeyAuthMiddleware` enforces the check at the Vapor layer; loopback clients (127.0.0.1 / ::1) always bypass to keep local tooling working.
+- User preferences (launch-at-login, LAN exposure, require-API-key) live in `SettingsStore` and are persisted via `UserDefaults`. Launch-at-login uses `SMAppService.mainApp` (no helper target).
 - Large Whisper models live outside the repo; configure via the app UI; never commit model files.
 
 ## Platform Assumptions

--- a/README.md
+++ b/README.md
@@ -223,6 +223,33 @@ Streaming:
 - Streaming sends one JSON chunk with `speaker_segments` when diarization completes.
 - Then the standard `end` event is sent.
 
+## Preferences
+
+Toggles available from the menu bar:
+
+- **Launch at Login** — registers WhisperServer as a login item via `SMAppService`, so the server starts automatically when you sign in. You can also revoke this from *System Settings → General → Login Items*.
+- **Expose on Local Network** — binds the HTTP server to `0.0.0.0:12017` instead of `localhost`, so other devices on your LAN (phone, another Mac) can reach the API. When enabled, the menu shows the full URL (e.g. `http://192.168.1.42:12017`) and offers a *Copy Server URL* action.
+- **Require API Key** — appears under the LAN URL when LAN exposure is on. When enabled, LAN clients must present a bearer token; requests from this Mac (`127.0.0.1` / `::1`) always bypass the check so local tooling keeps working.
+
+### API key authentication
+
+When *Require API Key* is on for the first time, WhisperServer generates a random key (`ws-` prefix + 64 hex chars) and stores it in the macOS Keychain. Clients must send it in the `Authorization` header:
+
+```bash
+curl -X POST http://192.168.1.42:12017/v1/audio/transcriptions \
+  -H "Authorization: Bearer ws-<your-key>" \
+  -F file=@audio.wav
+```
+
+The menu exposes two actions while the toggle is on:
+
+- **Copy API Key** — copies the current key to the clipboard.
+- **Regenerate API Key…** — replaces the key; any existing clients stop working until they receive the new value. The new key is copied to your clipboard automatically.
+
+Turning *Require API Key* off (or turning LAN exposure off entirely) does not delete the key — it stays in the Keychain so the same key works when you re-enable the toggle.
+
+> On first connection, macOS may show a prompt asking you to allow incoming connections for WhisperServer — that's the macOS Application Firewall, unrelated to the app itself.
+
 ## Build from Source
 If you want to build WhisperServer yourself:
 

--- a/WhisperServer/APIKeyStore.swift
+++ b/WhisperServer/APIKeyStore.swift
@@ -160,7 +160,12 @@ struct APIKeyAuthMiddleware: AsyncMiddleware {
             return try await next.respond(to: request)
         }
 
+        // Reject obviously oversized tokens up front so an attacker cannot
+        // push arbitrarily large `Authorization` headers through the full
+        // constant-time compare and waste event-loop cycles. Our tokens are
+        // 67 chars (`ws-` + 64 hex); 128 is a comfortable upper bound.
         guard let bearer = request.headers.bearerAuthorization,
+              bearer.token.utf8.count <= 128,
               let expected = APIKeyStore.shared.current(),
               Self.constantTimeEqual(bearer.token, expected) else {
             throw Abort(.unauthorized, reason: "Missing or invalid API key")
@@ -176,16 +181,20 @@ struct APIKeyAuthMiddleware: AsyncMiddleware {
     }
 
     private static func constantTimeEqual(_ lhs: String, _ rhs: String) -> Bool {
-        let left = Array(lhs.utf8)
-        let right = Array(rhs.utf8)
-        // Fold the length difference into `diff` and iterate over the longer
-        // of the two buffers so unequal lengths don't short-circuit the compare.
-        let maxCount = max(left.count, right.count)
-        var diff = UInt(left.count ^ right.count)
-        for index in 0..<maxCount {
-            let leftByte = index < left.count ? UInt(left[index]) : 0
-            let rightByte = index < right.count ? UInt(right[index]) : 0
-            diff |= leftByte ^ rightByte
+        // Iterate the UTF-8 views directly — no `Array(...)` copy, so the NIO
+        // event loop doesn't take an attacker-controlled heap allocation per
+        // request. Fold the length difference into `diff` and walk both views
+        // up to `max(count)` so unequal lengths don't short-circuit the compare.
+        let lhsBytes = lhs.utf8
+        let rhsBytes = rhs.utf8
+        let maxCount = max(lhsBytes.count, rhsBytes.count)
+        var diff = UInt(lhsBytes.count ^ rhsBytes.count)
+        var lhsIter = lhsBytes.makeIterator()
+        var rhsIter = rhsBytes.makeIterator()
+        for _ in 0..<maxCount {
+            let lhsByte = UInt(lhsIter.next() ?? 0)
+            let rhsByte = UInt(rhsIter.next() ?? 0)
+            diff |= lhsByte ^ rhsByte
         }
         return diff == 0
     }

--- a/WhisperServer/APIKeyStore.swift
+++ b/WhisperServer/APIKeyStore.swift
@@ -15,6 +15,17 @@ import NIOCore
 final class APIKeyStore {
     static let shared = APIKeyStore()
 
+    enum StoreError: LocalizedError {
+        case keychainFailure(OSStatus)
+
+        var errorDescription: String? {
+            switch self {
+            case .keychainFailure(let status):
+                return "Keychain operation failed (status \(status))."
+            }
+        }
+    }
+
     private let service: String
     private let account = "whisper-api-key"
 
@@ -25,11 +36,12 @@ final class APIKeyStore {
     // MARK: - Public API
 
     /// Returns the current key, generating and persisting one on first access if needed.
+    /// Throws if the Keychain write fails so callers can surface the error to the user.
     @discardableResult
-    func ensureExists() -> String {
+    func ensureExists() throws -> String {
         if let existing = current() { return existing }
         let fresh = Self.generateToken()
-        save(fresh)
+        try save(fresh)
         return fresh
     }
 
@@ -49,10 +61,11 @@ final class APIKeyStore {
     }
 
     /// Generates and stores a new key, replacing any existing one.
+    /// Throws if the Keychain write fails, leaving the previously stored key untouched.
     @discardableResult
-    func regenerate() -> String {
+    func regenerate() throws -> String {
         let fresh = Self.generateToken()
-        save(fresh)
+        try save(fresh)
         return fresh
     }
 
@@ -66,7 +79,7 @@ final class APIKeyStore {
         ]
     }
 
-    private func save(_ token: String) {
+    private func save(_ token: String) throws {
         let data = Data(token.utf8)
         var query = baseQuery()
 
@@ -78,9 +91,11 @@ final class APIKeyStore {
             let addStatus = SecItemAdd(query as CFDictionary, nil)
             if addStatus != errSecSuccess {
                 print("❌ Failed to store API key in Keychain (status \(addStatus))")
+                throw StoreError.keychainFailure(addStatus)
             }
         } else if updateStatus != errSecSuccess {
             print("❌ Failed to update API key in Keychain (status \(updateStatus))")
+            throw StoreError.keychainFailure(updateStatus)
         }
     }
 
@@ -98,8 +113,11 @@ final class APIKeyStore {
 
 // MARK: - Vapor Middleware
 
-/// Enforces Bearer token authentication when LAN exposure AND key-requirement are both on.
-/// Loopback clients (127.0.0.1, ::1) are always allowed through so local dev is unaffected.
+/// Enforces Bearer token authentication on non-loopback requests when
+/// `SettingsStore.requireAPIKey` is on. Loopback clients (127.0.0.1 / ::1)
+/// always bypass. When LAN exposure is off the server binds to `localhost`
+/// only, so all inbound traffic is loopback and this middleware naturally
+/// no-ops regardless of the `requireAPIKey` flag.
 struct APIKeyAuthMiddleware: AsyncMiddleware {
     func respond(to request: Request, chainingTo next: AsyncResponder) async throws -> Response {
         if Self.isLoopback(request.remoteAddress) {

--- a/WhisperServer/APIKeyStore.swift
+++ b/WhisperServer/APIKeyStore.swift
@@ -29,6 +29,11 @@ final class APIKeyStore {
     private let service: String
     private let account = "whisper-api-key"
 
+    /// In-memory cache so middleware doesn't hit `securityd` on every LAN request.
+    /// Populated lazily on first read; refreshed on every successful `save(_:)`.
+    private let cacheLock = NSLock()
+    private var cachedToken: String?
+
     private init() {
         self.service = Bundle.main.bundleIdentifier ?? "pfrankov.WhisperServer"
     }
@@ -46,7 +51,25 @@ final class APIKeyStore {
     }
 
     /// Returns the current key if one is stored, otherwise nil.
+    /// Reads from an in-memory cache after the first Keychain fetch so
+    /// hot request paths don't pay the synchronous IPC round-trip every time.
     func current() -> String? {
+        cacheLock.lock()
+        if let cached = cachedToken {
+            cacheLock.unlock()
+            return cached
+        }
+        cacheLock.unlock()
+
+        guard let token = readFromKeychain() else { return nil }
+
+        cacheLock.lock()
+        cachedToken = token
+        cacheLock.unlock()
+        return token
+    }
+
+    private func readFromKeychain() -> String? {
         var query = baseQuery()
         query[kSecReturnData as String] = true
         query[kSecMatchLimit as String] = kSecMatchLimitOne
@@ -97,6 +120,12 @@ final class APIKeyStore {
             print("❌ Failed to update API key in Keychain (status \(updateStatus))")
             throw StoreError.keychainFailure(updateStatus)
         }
+
+        // Keychain write succeeded — refresh the in-memory cache so the next
+        // middleware read sees the new token without a Keychain round-trip.
+        cacheLock.lock()
+        cachedToken = token
+        cacheLock.unlock()
     }
 
     private static func generateToken() -> String {

--- a/WhisperServer/APIKeyStore.swift
+++ b/WhisperServer/APIKeyStore.swift
@@ -1,0 +1,136 @@
+//
+//  APIKeyStore.swift
+//  WhisperServer
+//
+//  Keychain-backed API key storage and Vapor auth middleware.
+//
+
+import Foundation
+import Security
+import Vapor
+import NIOCore
+
+/// Persistent API key used to authenticate LAN clients.
+/// Stored in the macOS Keychain under the app's bundle identifier.
+final class APIKeyStore {
+    static let shared = APIKeyStore()
+
+    private let service: String
+    private let account = "whisper-api-key"
+
+    private init() {
+        self.service = Bundle.main.bundleIdentifier ?? "pfrankov.WhisperServer"
+    }
+
+    // MARK: - Public API
+
+    /// Returns the current key, generating and persisting one on first access if needed.
+    @discardableResult
+    func ensureExists() -> String {
+        if let existing = current() { return existing }
+        let fresh = Self.generateToken()
+        save(fresh)
+        return fresh
+    }
+
+    /// Returns the current key if one is stored, otherwise nil.
+    func current() -> String? {
+        var query = baseQuery()
+        query[kSecReturnData as String] = true
+        query[kSecMatchLimit as String] = kSecMatchLimitOne
+
+        var item: AnyObject?
+        let status = SecItemCopyMatching(query as CFDictionary, &item)
+        guard status == errSecSuccess, let data = item as? Data,
+              let token = String(data: data, encoding: .utf8) else {
+            return nil
+        }
+        return token
+    }
+
+    /// Generates and stores a new key, replacing any existing one.
+    @discardableResult
+    func regenerate() -> String {
+        let fresh = Self.generateToken()
+        save(fresh)
+        return fresh
+    }
+
+    // MARK: - Private
+
+    private func baseQuery() -> [String: Any] {
+        return [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: account
+        ]
+    }
+
+    private func save(_ token: String) {
+        let data = Data(token.utf8)
+        var query = baseQuery()
+
+        let attributes: [String: Any] = [kSecValueData as String: data]
+        let updateStatus = SecItemUpdate(query as CFDictionary, attributes as CFDictionary)
+
+        if updateStatus == errSecItemNotFound {
+            query[kSecValueData as String] = data
+            let addStatus = SecItemAdd(query as CFDictionary, nil)
+            if addStatus != errSecSuccess {
+                print("❌ Failed to store API key in Keychain (status \(addStatus))")
+            }
+        } else if updateStatus != errSecSuccess {
+            print("❌ Failed to update API key in Keychain (status \(updateStatus))")
+        }
+    }
+
+    private static func generateToken() -> String {
+        var bytes = [UInt8](repeating: 0, count: 32)
+        let status = SecRandomCopyBytes(kSecRandomDefault, bytes.count, &bytes)
+        if status != errSecSuccess {
+            // Fallback: RNG pulled from /dev/urandom via arc4random_buf
+            for index in bytes.indices { bytes[index] = UInt8.random(in: 0...255) }
+        }
+        let hex = bytes.map { String(format: "%02x", $0) }.joined()
+        return "ws-\(hex)"
+    }
+}
+
+// MARK: - Vapor Middleware
+
+/// Enforces Bearer token authentication when LAN exposure AND key-requirement are both on.
+/// Loopback clients (127.0.0.1, ::1) are always allowed through so local dev is unaffected.
+struct APIKeyAuthMiddleware: AsyncMiddleware {
+    func respond(to request: Request, chainingTo next: AsyncResponder) async throws -> Response {
+        if Self.isLoopback(request.remoteAddress) {
+            return try await next.respond(to: request)
+        }
+
+        guard SettingsStore.shared.requireAPIKey else {
+            return try await next.respond(to: request)
+        }
+
+        guard let bearer = request.headers.bearerAuthorization,
+              let expected = APIKeyStore.shared.current(),
+              Self.constantTimeEqual(bearer.token, expected) else {
+            throw Abort(.unauthorized, reason: "Missing or invalid API key")
+        }
+
+        return try await next.respond(to: request)
+    }
+
+    private static func isLoopback(_ address: SocketAddress?) -> Bool {
+        guard let ip = address?.ipAddress else { return false }
+        if ip == "127.0.0.1" || ip == "::1" || ip == "::ffff:127.0.0.1" { return true }
+        return ip.hasPrefix("127.")
+    }
+
+    private static func constantTimeEqual(_ lhs: String, _ rhs: String) -> Bool {
+        let left = Array(lhs.utf8)
+        let right = Array(rhs.utf8)
+        guard left.count == right.count else { return false }
+        var diff: UInt8 = 0
+        for index in left.indices { diff |= left[index] ^ right[index] }
+        return diff == 0
+    }
+}

--- a/WhisperServer/APIKeyStore.swift
+++ b/WhisperServer/APIKeyStore.swift
@@ -103,7 +103,8 @@ final class APIKeyStore {
         var bytes = [UInt8](repeating: 0, count: 32)
         let status = SecRandomCopyBytes(kSecRandomDefault, bytes.count, &bytes)
         if status != errSecSuccess {
-            // Fallback: RNG pulled from /dev/urandom via arc4random_buf
+            // Fallback: Swift's SystemRandomNumberGenerator (backed by arc4random
+            // on Darwin) is cryptographically suitable as a last-resort source.
             for index in bytes.indices { bytes[index] = UInt8.random(in: 0...255) }
         }
         let hex = bytes.map { String(format: "%02x", $0) }.joined()
@@ -124,7 +125,9 @@ struct APIKeyAuthMiddleware: AsyncMiddleware {
             return try await next.respond(to: request)
         }
 
-        guard SettingsStore.shared.requireAPIKey else {
+        // Thread-safe read: SettingsStore routes the value through UserDefaults,
+        // which we can safely query from the NIO event loop without hopping to main.
+        guard SettingsStore.isAPIKeyRequired else {
             return try await next.respond(to: request)
         }
 
@@ -146,9 +149,15 @@ struct APIKeyAuthMiddleware: AsyncMiddleware {
     private static func constantTimeEqual(_ lhs: String, _ rhs: String) -> Bool {
         let left = Array(lhs.utf8)
         let right = Array(rhs.utf8)
-        guard left.count == right.count else { return false }
-        var diff: UInt8 = 0
-        for index in left.indices { diff |= left[index] ^ right[index] }
+        // Fold the length difference into `diff` and iterate over the longer
+        // of the two buffers so unequal lengths don't short-circuit the compare.
+        let maxCount = max(left.count, right.count)
+        var diff = UInt(left.count ^ right.count)
+        for index in 0..<maxCount {
+            let leftByte = index < left.count ? UInt(left[index]) : 0
+            let rightByte = index < right.count ? UInt(right[index]) : 0
+            diff |= leftByte ^ rightByte
+        }
         return diff == 0
     }
 }

--- a/WhisperServer/MenuBarService.swift
+++ b/WhisperServer/MenuBarService.swift
@@ -16,12 +16,26 @@ final class MenuBarService: ObservableObject {
         case status = 1000
         case server = 1001
         case download = 1002
+        case launchAtLogin = 1003
+        case exposeOnLAN = 1004
+        case lanURL = 1005
+        case lanCopy = 1006
+        case requireAPIKey = 1007
+        case apiKeyCopy = 1008
+        case apiKeyRegenerate = 1009
+        case preferences = 1010
     }
-    
+
+    /// Tags that describe the dynamic LAN sub-section under the Expose toggle (inside Preferences).
+    private static let lanSectionTags: [MenuItemTags] = [
+        .lanURL, .lanCopy, .requireAPIKey, .apiKeyCopy, .apiKeyRegenerate
+    ]
+
     // MARK: - Properties
-    
+
     private var statusItem: NSStatusItem?
     private let modelManager: ModelManager
+    private let settingsStore: SettingsStore
     private weak var serverCoordinator: ServerCoordinator?
     private let idleIconName = "waveform"
     private let processingIconName = "waveform.circle.fill"
@@ -30,10 +44,12 @@ final class MenuBarService: ObservableObject {
     private var baseTooltip = "WhisperServer - Ready"
     private var isCurrentlyProcessing = false
     private let progressResetDelay: TimeInterval = 1.0
+    private var currentServerPort: Int = 12017
     // MARK: - Initialization
     
-    init(modelManager: ModelManager) {
+    init(modelManager: ModelManager, settingsStore: SettingsStore = .shared) {
         self.modelManager = modelManager
+        self.settingsStore = settingsStore
     }
     
     // MARK: - Public Interface
@@ -56,8 +72,9 @@ final class MenuBarService: ObservableObject {
     func updateServerStatus(_ isRunning: Bool, port: Int) {
         guard let menu = statusItem?.menu,
               let serverItem = menu.item(withTag: MenuItemTags.server.rawValue) else { return }
-        
+
         DispatchQueue.main.async {
+            self.currentServerPort = port
             if isRunning {
                 serverItem.title = "Server: Running on port \(port)"
                 serverItem.image = NSImage(systemSymbolName: "checkmark.circle", accessibilityDescription: nil)
@@ -65,6 +82,7 @@ final class MenuBarService: ObservableObject {
                 serverItem.title = "Server: Stopped"
                 serverItem.image = NSImage(systemSymbolName: "xmark.circle", accessibilityDescription: nil)
             }
+            self.refreshLANMenuVisibility()
         }
     }
     
@@ -191,33 +209,163 @@ final class MenuBarService: ObservableObject {
     
     private func createMenu() {
         let menu = NSMenu()
-        
+
         // Server status
         let serverItem = NSMenuItem(title: "Server: Waiting for initialization...", action: nil, keyEquivalent: "")
         serverItem.toolTip = "HTTP server will start after initialization is complete"
         serverItem.tag = MenuItemTags.server.rawValue
         menu.addItem(serverItem)
-        
+
         // Model selection submenu
         menu.addItem(NSMenuItem.separator())
         createModelSelectionMenu(menu)
-        
+
+        // Preferences submenu
+        menu.addItem(NSMenuItem.separator())
+        let preferencesItem = NSMenuItem(title: "Preferences", action: nil, keyEquivalent: "")
+        preferencesItem.tag = MenuItemTags.preferences.rawValue
+        preferencesItem.submenu = buildPreferencesSubmenu()
+        menu.addItem(preferencesItem)
+
         // Quit option
         menu.addItem(NSMenuItem.separator())
         let quitItem = NSMenuItem(title: "Quit", action: #selector(quitApp), keyEquivalent: "q")
         quitItem.target = self
         menu.addItem(quitItem)
-#if DEBUG
-        let resetItem = NSMenuItem(title: "Reset Application Data", action: #selector(resetApplicationData(_:)), keyEquivalent: "")
-        resetItem.target = self
-        resetItem.toolTip = "Remove all saved preferences and cached models"
-        menu.addItem(resetItem)
-        print("🔧 Menu items:", menu.items.map { $0.title })
-#endif
-        
+
         statusItem?.menu = menu
     }
     
+    private func buildPreferencesSubmenu() -> NSMenu {
+        let submenu = NSMenu(title: "Preferences")
+
+        let launchItem = NSMenuItem(
+            title: "Launch at Login",
+            action: #selector(toggleLaunchAtLogin(_:)),
+            keyEquivalent: ""
+        )
+        launchItem.target = self
+        launchItem.tag = MenuItemTags.launchAtLogin.rawValue
+        launchItem.state = settingsStore.launchAtLogin ? .on : .off
+        launchItem.toolTip = "Start WhisperServer automatically when you log in"
+        submenu.addItem(launchItem)
+
+        let exposeItem = NSMenuItem(
+            title: "Expose on Local Network",
+            action: #selector(toggleExposeOnLAN(_:)),
+            keyEquivalent: ""
+        )
+        exposeItem.target = self
+        exposeItem.tag = MenuItemTags.exposeOnLAN.rawValue
+        exposeItem.state = settingsStore.exposeOnLAN ? .on : .off
+        exposeItem.toolTip = "Bind the HTTP server to 0.0.0.0 so other devices on your network can reach it"
+        submenu.addItem(exposeItem)
+
+        if settingsStore.exposeOnLAN {
+            appendLANMenuItems(to: submenu)
+        }
+
+#if DEBUG
+        submenu.addItem(NSMenuItem.separator())
+        let resetItem = NSMenuItem(
+            title: "Reset Application Data…",
+            action: #selector(resetApplicationData(_:)),
+            keyEquivalent: ""
+        )
+        resetItem.target = self
+        resetItem.toolTip = "Remove all saved preferences and cached models"
+        submenu.addItem(resetItem)
+#endif
+
+        return submenu
+    }
+
+    private func appendLANMenuItems(to menu: NSMenu) {
+        for item in buildLANSectionItems() { menu.addItem(item) }
+    }
+
+    private func lanURLTitle() -> String {
+        if let ip = NetworkUtility.primaryLocalIPv4() {
+            return "    http://\(ip):\(currentServerPort)"
+        }
+        return "    LAN address unavailable"
+    }
+
+    /// Constructs the LAN sub-section items (order matters).
+    private func buildLANSectionItems() -> [NSMenuItem] {
+        var items: [NSMenuItem] = []
+
+        let urlItem = NSMenuItem(title: lanURLTitle(), action: nil, keyEquivalent: "")
+        urlItem.tag = MenuItemTags.lanURL.rawValue
+        urlItem.isEnabled = false
+        urlItem.toolTip = "Address other devices on your network can use to reach this server"
+        items.append(urlItem)
+
+        let copyURLItem = NSMenuItem(
+            title: "Copy Server URL",
+            action: #selector(copyServerURL(_:)),
+            keyEquivalent: ""
+        )
+        copyURLItem.target = self
+        copyURLItem.tag = MenuItemTags.lanCopy.rawValue
+        items.append(copyURLItem)
+
+        let requireItem = NSMenuItem(
+            title: "Require API Key",
+            action: #selector(toggleRequireAPIKey(_:)),
+            keyEquivalent: ""
+        )
+        requireItem.target = self
+        requireItem.tag = MenuItemTags.requireAPIKey.rawValue
+        requireItem.state = settingsStore.requireAPIKey ? .on : .off
+        requireItem.toolTip = "Reject LAN requests without a valid Authorization: Bearer token"
+        items.append(requireItem)
+
+        if settingsStore.requireAPIKey {
+            let copyKeyItem = NSMenuItem(
+                title: "Copy API Key",
+                action: #selector(copyAPIKey(_:)),
+                keyEquivalent: ""
+            )
+            copyKeyItem.target = self
+            copyKeyItem.tag = MenuItemTags.apiKeyCopy.rawValue
+            items.append(copyKeyItem)
+
+            let regenerateItem = NSMenuItem(
+                title: "Regenerate API Key…",
+                action: #selector(regenerateAPIKey(_:)),
+                keyEquivalent: ""
+            )
+            regenerateItem.target = self
+            regenerateItem.tag = MenuItemTags.apiKeyRegenerate.rawValue
+            items.append(regenerateItem)
+        }
+
+        return items
+    }
+
+    /// Removes and re-creates the LAN sub-section inside the Preferences submenu.
+    private func refreshLANMenuVisibility() {
+        guard let topMenu = statusItem?.menu,
+              let prefItem = topMenu.item(withTag: MenuItemTags.preferences.rawValue),
+              let prefMenu = prefItem.submenu,
+              let exposeIndex = prefMenu.items.firstIndex(where: { $0.tag == MenuItemTags.exposeOnLAN.rawValue }) else { return }
+
+        // Wipe any existing LAN-section items (idempotent, order-insensitive).
+        for tag in Self.lanSectionTags {
+            let index = prefMenu.indexOfItem(withTag: tag.rawValue)
+            if index >= 0 { prefMenu.removeItem(at: index) }
+        }
+
+        guard settingsStore.exposeOnLAN else { return }
+
+        var insertAt = exposeIndex + 1
+        for item in buildLANSectionItems() {
+            prefMenu.insertItem(item, at: insertAt)
+            insertAt += 1
+        }
+    }
+
     private func createModelSelectionMenu(_ parentMenu: NSMenu) {
         let modelSelectionMenuItem = NSMenuItem(title: "Select Model", action: nil, keyEquivalent: "")
         let modelSelectionSubmenu = NSMenu()
@@ -332,6 +480,77 @@ final class MenuBarService: ObservableObject {
         let importItem = NSMenuItem(title: "Import Whisper Model…", action: #selector(importWhisperModel), keyEquivalent: "")
         importItem.target = self
         submenu.addItem(importItem)
+
+        let deleteParent = NSMenuItem(title: "Delete Downloaded Models", action: nil, keyEquivalent: "")
+        deleteParent.submenu = buildDeleteDownloadedModelsSubmenu()
+        submenu.addItem(deleteParent)
+    }
+
+    private func buildDeleteDownloadedModelsSubmenu() -> NSMenu {
+        let submenu = NSMenu(title: "Delete Downloaded Models")
+
+        let revealItem = NSMenuItem(
+            title: "Show in Finder",
+            action: #selector(showModelsInFinder(_:)),
+            keyEquivalent: ""
+        )
+        revealItem.target = self
+        revealItem.toolTip = "Open the folder where model files are stored"
+        if #available(macOS 11.0, *) {
+            revealItem.image = NSImage(systemSymbolName: "folder", accessibilityDescription: "Show in Finder")
+        }
+        submenu.addItem(revealItem)
+        submenu.addItem(NSMenuItem.separator())
+
+        let downloadedWhisperIDs = modelManager.downloadedBundledWhisperModelIDs()
+        let fluidDownloaded = modelManager.isFluidModelDownloaded()
+
+        if downloadedWhisperIDs.isEmpty && !fluidDownloaded {
+            let emptyItem = NSMenuItem(title: "No downloaded models", action: nil, keyEquivalent: "")
+            emptyItem.isEnabled = false
+            submenu.addItem(emptyItem)
+            return submenu
+        }
+
+        if fluidDownloaded {
+            let fluidModel = FluidTranscriptionService.defaultModel
+            let title = "\(fluidModel.displayName) (FluidAudio)"
+            let item = NSMenuItem(
+                title: title,
+                action: #selector(confirmDeleteDownloadedFluid(_:)),
+                keyEquivalent: ""
+            )
+            item.target = self
+            item.representedObject = fluidModel.id
+            item.toolTip = "Remove cached FluidAudio model files"
+            if #available(macOS 11.0, *) {
+                item.image = NSImage(systemSymbolName: "trash", accessibilityDescription: "Delete Fluid model")
+            }
+            submenu.addItem(item)
+        }
+
+        if !downloadedWhisperIDs.isEmpty && fluidDownloaded {
+            submenu.addItem(NSMenuItem.separator())
+        }
+
+        let whisperEntries = modelManager.availableModels
+            .filter { downloadedWhisperIDs.contains($0.id) }
+        for model in whisperEntries {
+            let item = NSMenuItem(
+                title: model.name,
+                action: #selector(confirmDeleteDownloadedWhisper(_:)),
+                keyEquivalent: ""
+            )
+            item.target = self
+            item.representedObject = model.id
+            item.toolTip = "Remove cached files for this Whisper model"
+            if #available(macOS 11.0, *) {
+                item.image = NSImage(systemSymbolName: "trash", accessibilityDescription: "Delete Whisper model")
+            }
+            submenu.addItem(item)
+        }
+
+        return submenu
     }
 
     private func addModelMenuItems(for model: Model, to submenu: NSMenu) {
@@ -480,6 +699,75 @@ final class MenuBarService: ObservableObject {
         }
     }
     
+    @objc private func showModelsInFinder(_ sender: NSMenuItem) {
+        guard let dir = modelManager.modelsDirectoryURL else {
+            NSSound.beep()
+            return
+        }
+        // Create the directory if it doesn't exist so Finder has something to open.
+        try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        NSWorkspace.shared.open(dir)
+    }
+
+    @objc private func confirmDeleteDownloadedWhisper(_ sender: NSMenuItem) {
+        guard let modelId = sender.representedObject as? String,
+              let model = modelManager.availableModels.first(where: { $0.id == modelId }) else { return }
+
+        let alert = NSAlert()
+        alert.messageText = "Delete \"\(model.name)\"?"
+        alert.informativeText = "The downloaded files will be removed. The model will be re-downloaded automatically the next time you use it."
+        alert.alertStyle = .warning
+        alert.addButton(withTitle: "Delete")
+        alert.addButton(withTitle: "Cancel")
+
+        NSApp.activate(ignoringOtherApps: true)
+        guard alert.runModal() == .alertFirstButtonReturn else { return }
+
+        serverCoordinator?.stopServer()
+        defer { serverCoordinator?.restartServer() }
+
+        do {
+            try modelManager.deleteDownloadedBundledWhisperModel(id: modelId)
+            refreshModelSelectionMenu()
+        } catch {
+            let errorAlert = NSAlert()
+            errorAlert.messageText = "Unable to delete model"
+            errorAlert.informativeText = error.localizedDescription
+            errorAlert.alertStyle = .warning
+            errorAlert.addButton(withTitle: "OK")
+            errorAlert.runModal()
+        }
+    }
+
+    @objc private func confirmDeleteDownloadedFluid(_ sender: NSMenuItem) {
+        let modelName = FluidTranscriptionService.defaultModel.displayName
+
+        let alert = NSAlert()
+        alert.messageText = "Delete \"\(modelName)\"?"
+        alert.informativeText = "The FluidAudio model cache will be removed. It will be re-downloaded automatically the next time you use it."
+        alert.alertStyle = .warning
+        alert.addButton(withTitle: "Delete")
+        alert.addButton(withTitle: "Cancel")
+
+        NSApp.activate(ignoringOtherApps: true)
+        guard alert.runModal() == .alertFirstButtonReturn else { return }
+
+        serverCoordinator?.stopServer()
+        defer { serverCoordinator?.restartServer() }
+
+        do {
+            try modelManager.deleteDownloadedFluidModel()
+            refreshModelSelectionMenu()
+        } catch {
+            let errorAlert = NSAlert()
+            errorAlert.messageText = "Unable to delete model"
+            errorAlert.informativeText = error.localizedDescription
+            errorAlert.alertStyle = .warning
+            errorAlert.addButton(withTitle: "OK")
+            errorAlert.runModal()
+        }
+    }
+
     @objc private func confirmDeleteModel(_ sender: NSMenuItem) {
         guard let modelId = sender.representedObject as? String,
               let model = modelManager.availableModels.first(where: { $0.id == modelId }) else { return }
@@ -509,6 +797,117 @@ final class MenuBarService: ObservableObject {
         }
     }
     
+    @objc private func toggleLaunchAtLogin(_ sender: NSMenuItem) {
+        settingsStore.launchAtLogin.toggle()
+        sender.state = settingsStore.launchAtLogin ? .on : .off
+    }
+
+    @objc private func toggleExposeOnLAN(_ sender: NSMenuItem) {
+        let goingOn = !settingsStore.exposeOnLAN
+
+        if goingOn && !settingsStore.lanWarningShown {
+            let alert = NSAlert()
+            alert.messageText = "Expose server on your local network?"
+            alert.informativeText = """
+            Other devices on your network will be able to send requests to the \
+            server while this option is enabled. By default no authentication is \
+            required — enable "Require API Key" below to restrict access.
+
+            macOS may ask you to allow incoming connections the first time.
+            """
+            alert.alertStyle = .warning
+            alert.addButton(withTitle: "Enable")
+            alert.addButton(withTitle: "Cancel")
+
+            NSApp.activate(ignoringOtherApps: true)
+            guard alert.runModal() == .alertFirstButtonReturn else { return }
+            settingsStore.lanWarningShown = true
+        }
+
+        settingsStore.exposeOnLAN = goingOn
+        sender.state = goingOn ? .on : .off
+        refreshLANMenuVisibility()
+
+        serverCoordinator?.restartServer()
+    }
+
+    @objc private func copyServerURL(_ sender: NSMenuItem) {
+        guard let ip = NetworkUtility.primaryLocalIPv4() else {
+            NSSound.beep()
+            return
+        }
+        let url = "http://\(ip):\(currentServerPort)"
+        let pasteboard = NSPasteboard.general
+        pasteboard.clearContents()
+        pasteboard.setString(url, forType: .string)
+    }
+
+    @objc private func toggleRequireAPIKey(_ sender: NSMenuItem) {
+        let goingOn = !settingsStore.requireAPIKey
+
+        if goingOn {
+            let token = APIKeyStore.shared.ensureExists()
+            if !settingsStore.apiKeyWarningShown {
+                let alert = NSAlert()
+                alert.messageText = "API key required for LAN requests"
+                alert.informativeText = """
+                An API key has been generated and stored in your Keychain. \
+                Copy it from the menu (Copy API Key) and include it with every \
+                request as:
+
+                    Authorization: Bearer \(token)
+
+                Requests from this Mac (localhost) are always allowed without \
+                the key.
+                """
+                alert.alertStyle = .informational
+                alert.addButton(withTitle: "OK")
+
+                NSApp.activate(ignoringOtherApps: true)
+                alert.runModal()
+                settingsStore.apiKeyWarningShown = true
+            }
+        }
+
+        settingsStore.requireAPIKey = goingOn
+        sender.state = goingOn ? .on : .off
+        refreshLANMenuVisibility()
+    }
+
+    @objc private func copyAPIKey(_ sender: NSMenuItem) {
+        let token = APIKeyStore.shared.ensureExists()
+        let pasteboard = NSPasteboard.general
+        pasteboard.clearContents()
+        pasteboard.setString(token, forType: .string)
+    }
+
+    @objc private func regenerateAPIKey(_ sender: NSMenuItem) {
+        let alert = NSAlert()
+        alert.messageText = "Regenerate API key?"
+        alert.informativeText = """
+        A new key will replace the current one. Any client using the current \
+        key will stop working until you update it.
+        """
+        alert.alertStyle = .warning
+        alert.addButton(withTitle: "Regenerate")
+        alert.addButton(withTitle: "Cancel")
+
+        NSApp.activate(ignoringOtherApps: true)
+        guard alert.runModal() == .alertFirstButtonReturn else { return }
+
+        let fresh = APIKeyStore.shared.regenerate()
+        let pasteboard = NSPasteboard.general
+        pasteboard.clearContents()
+        pasteboard.setString(fresh, forType: .string)
+
+        let confirmation = NSAlert()
+        confirmation.messageText = "API key regenerated"
+        confirmation.informativeText = "The new key has been copied to your clipboard."
+        confirmation.alertStyle = .informational
+        confirmation.addButton(withTitle: "OK")
+        confirmation.runModal()
+    }
+
     @objc private func quitApp() {
         NSApp.terminate(self)
     }

--- a/WhisperServer/MenuBarService.swift
+++ b/WhisperServer/MenuBarService.swift
@@ -544,7 +544,6 @@ final class MenuBarService: ObservableObject {
                 keyEquivalent: ""
             )
             item.target = self
-            item.representedObject = fluidModel.id
             item.toolTip = "Remove cached FluidAudio model files"
             if #available(macOS 11.0, *) {
                 item.image = NSImage(systemSymbolName: "trash", accessibilityDescription: "Delete Fluid model")
@@ -729,13 +728,25 @@ final class MenuBarService: ObservableObject {
         }
     }
     
-    @objc private func showModelsInFinder(_ sender: NSMenuItem) {
+    @objc private func showModelsInFinder(_: NSMenuItem) {
         guard let dir = modelManager.modelsDirectoryURL else {
             NSSound.beep()
             return
         }
         // Create the directory if it doesn't exist so Finder has something to open.
-        try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        // Surface any filesystem failure to the user instead of silently no-oping.
+        do {
+            try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        } catch {
+            NSApp.activate(ignoringOtherApps: true)
+            let alert = NSAlert()
+            alert.messageText = "Unable to open models folder"
+            alert.informativeText = error.localizedDescription
+            alert.alertStyle = .warning
+            alert.addButton(withTitle: "OK")
+            alert.runModal()
+            return
+        }
         NSWorkspace.shared.open(dir)
     }
 
@@ -770,7 +781,7 @@ final class MenuBarService: ObservableObject {
         }
     }
 
-    @objc private func confirmDeleteDownloadedFluid(_ sender: NSMenuItem) {
+    @objc private func confirmDeleteDownloadedFluid(_: NSMenuItem) {
         let modelName = FluidTranscriptionService.defaultModel.displayName
 
         let alert = NSAlert()

--- a/WhisperServer/MenuBarService.swift
+++ b/WhisperServer/MenuBarService.swift
@@ -757,8 +757,9 @@ final class MenuBarService: ObservableObject {
         defer { serverCoordinator?.restartServer() }
 
         do {
+            // ModelManager posts .modelManagerDidUpdate; the notification observer
+            // on refreshModelSelectionMenu rebuilds the submenu for us.
             try modelManager.deleteDownloadedBundledWhisperModel(id: modelId)
-            refreshModelSelectionMenu()
         } catch {
             let errorAlert = NSAlert()
             errorAlert.messageText = "Unable to delete model"
@@ -786,8 +787,9 @@ final class MenuBarService: ObservableObject {
         defer { serverCoordinator?.restartServer() }
 
         do {
+            // ModelManager posts .modelManagerDidUpdate; the notification observer
+            // on refreshModelSelectionMenu rebuilds the submenu for us.
             try modelManager.deleteDownloadedFluidModel()
-            refreshModelSelectionMenu()
         } catch {
             let errorAlert = NSAlert()
             errorAlert.messageText = "Unable to delete model"

--- a/WhisperServer/MenuBarService.swift
+++ b/WhisperServer/MenuBarService.swift
@@ -6,6 +6,7 @@
 //
 
 import AppKit
+import Combine
 import SwiftUI
 
 /// Service responsible for managing the menu bar interface
@@ -45,6 +46,8 @@ final class MenuBarService: ObservableObject {
     private var isCurrentlyProcessing = false
     private let progressResetDelay: TimeInterval = 1.0
     private var currentServerPort: Int = 12017
+    private var cancellables: Set<AnyCancellable> = []
+
     // MARK: - Initialization
     
     init(modelManager: ModelManager, settingsStore: SettingsStore = .shared) {
@@ -59,10 +62,30 @@ final class MenuBarService: ObservableObject {
 #if DEBUG
         print("🔧 DEBUG build detected: Reset menu item enabled.")
 #endif
-        
+
         configureStatusButton()
         createMenu()
         setupNotificationObservers()
+        observeSettings()
+    }
+
+    /// Keeps menu item state in sync with SettingsStore — covers async rollbacks
+    /// (e.g. SMAppService.register failing after the toggle was optimistically flipped).
+    private func observeSettings() {
+        settingsStore.$launchAtLogin
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] value in
+                self?.syncLaunchAtLoginMenuItem(to: value)
+            }
+            .store(in: &cancellables)
+    }
+
+    private func syncLaunchAtLoginMenuItem(to value: Bool) {
+        guard let topMenu = statusItem?.menu,
+              let prefItem = topMenu.item(withTag: MenuItemTags.preferences.rawValue),
+              let prefMenu = prefItem.submenu,
+              let item = prefMenu.item(withTag: MenuItemTags.launchAtLogin.rawValue) else { return }
+        item.state = value ? .on : .off
     }
     
     func setServerCoordinator(_ coordinator: ServerCoordinator) {
@@ -589,6 +612,13 @@ final class MenuBarService: ObservableObject {
             name: .modelManagerDidUpdate, 
             object: nil
         )
+
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(refreshModelSelectionMenu),
+            name: .modelIsReady,
+            object: nil
+        )
     }
     
     // MARK: - Menu Actions
@@ -798,8 +828,9 @@ final class MenuBarService: ObservableObject {
     }
     
     @objc private func toggleLaunchAtLogin(_ sender: NSMenuItem) {
+        // The checkmark is driven by the Combine observer on SettingsStore.$launchAtLogin,
+        // so transient failure rollbacks in applyLaunchAtLogin end up reflected in the UI.
         settingsStore.launchAtLogin.toggle()
-        sender.state = settingsStore.launchAtLogin ? .on : .off
     }
 
     @objc private func toggleExposeOnLAN(_ sender: NSMenuItem) {
@@ -846,7 +877,14 @@ final class MenuBarService: ObservableObject {
         let goingOn = !settingsStore.requireAPIKey
 
         if goingOn {
-            let token = APIKeyStore.shared.ensureExists()
+            let token: String
+            do {
+                token = try APIKeyStore.shared.ensureExists()
+            } catch {
+                presentAPIKeyFailureAlert(error: error)
+                return
+            }
+
             if !settingsStore.apiKeyWarningShown {
                 let alert = NSAlert()
                 alert.messageText = "API key required for LAN requests"
@@ -875,7 +913,13 @@ final class MenuBarService: ObservableObject {
     }
 
     @objc private func copyAPIKey(_ sender: NSMenuItem) {
-        let token = APIKeyStore.shared.ensureExists()
+        let token: String
+        do {
+            token = try APIKeyStore.shared.ensureExists()
+        } catch {
+            presentAPIKeyFailureAlert(error: error)
+            return
+        }
         let pasteboard = NSPasteboard.general
         pasteboard.clearContents()
         pasteboard.setString(token, forType: .string)
@@ -895,7 +939,13 @@ final class MenuBarService: ObservableObject {
         NSApp.activate(ignoringOtherApps: true)
         guard alert.runModal() == .alertFirstButtonReturn else { return }
 
-        let fresh = APIKeyStore.shared.regenerate()
+        let fresh: String
+        do {
+            fresh = try APIKeyStore.shared.regenerate()
+        } catch {
+            presentAPIKeyFailureAlert(error: error)
+            return
+        }
         let pasteboard = NSPasteboard.general
         pasteboard.clearContents()
         pasteboard.setString(fresh, forType: .string)
@@ -906,6 +956,16 @@ final class MenuBarService: ObservableObject {
         confirmation.alertStyle = .informational
         confirmation.addButton(withTitle: "OK")
         confirmation.runModal()
+    }
+
+    private func presentAPIKeyFailureAlert(error: Error) {
+        let alert = NSAlert()
+        alert.messageText = "Unable to store API key"
+        alert.informativeText = "\(error.localizedDescription)\n\nThe previous key (if any) was not replaced."
+        alert.alertStyle = .warning
+        alert.addButton(withTitle: "OK")
+        NSApp.activate(ignoringOtherApps: true)
+        alert.runModal()
     }
 
     @objc private func quitApp() {

--- a/WhisperServer/ModelManager.swift
+++ b/WhisperServer/ModelManager.swift
@@ -535,21 +535,25 @@ final class ModelManager: @unchecked Sendable {
             throw ModelDeletionError.modelNotFound(id)
         }
         guard let dir = modelsDirectory else {
-            throw ModelDeletionError.userModelsDirectoryUnavailable
+            throw ModelPreparationError.modelsDirectoryUnavailable
+        }
+
+        let removeIfExists: (URL) throws -> Void = { url in
+            if self.fileManager.fileExists(atPath: url.path) {
+                do {
+                    try self.fileManager.removeItem(at: url)
+                } catch {
+                    throw ModelDeletionError.fileRemovalFailed(path: url.path, underlying: error)
+                }
+            }
         }
 
         for fileInfo in model.files {
-            let fileURL = dir.appendingPathComponent(fileInfo.filename)
-            if fileManager.fileExists(atPath: fileURL.path) {
-                do { try fileManager.removeItem(at: fileURL) }
-                catch { throw ModelDeletionError.fileRemovalFailed(path: fileURL.path, underlying: error) }
-            }
+            try removeIfExists(dir.appendingPathComponent(fileInfo.filename))
+
             if fileInfo.type == "zip" {
                 let unzippedName = (fileInfo.filename as NSString).deletingPathExtension
-                let unzippedURL = dir.appendingPathComponent(unzippedName)
-                if fileManager.fileExists(atPath: unzippedURL.path) {
-                    try? fileManager.removeItem(at: unzippedURL)
-                }
+                try removeIfExists(dir.appendingPathComponent(unzippedName))
             }
         }
 

--- a/WhisperServer/ModelManager.swift
+++ b/WhisperServer/ModelManager.swift
@@ -115,6 +115,9 @@ final class ModelManager: @unchecked Sendable {
 
     private let fileManager = FileManager.default
     private var modelsDirectory: URL?
+
+    /// Public accessor to the directory where Whisper model files are cached.
+    var modelsDirectoryURL: URL? { modelsDirectory }
     private var userModelsDirectory: URL?
     private var currentDownloadTasks: [URLSessionDownloadTask] = []
     private var urlSession: URLSession!
@@ -500,6 +503,69 @@ final class ModelManager: @unchecked Sendable {
         if removedModelWasSelected, selectedModelID != nil {
             checkAndPrepareSelectedModel()
         }
+    }
+
+    // MARK: - Downloaded Model Inspection & Deletion
+
+    /// Returns the IDs of bundled Whisper models whose primary .bin file is present on disk.
+    func downloadedBundledWhisperModelIDs() -> Set<String> {
+        guard let dir = modelsDirectory else { return [] }
+        var result: Set<String> = []
+        for model in availableModels where !model.id.hasPrefix("user-") {
+            guard let binFile = model.files.first(where: { $0.type == "bin" }) else { continue }
+            let path = dir.appendingPathComponent(binFile.filename).path
+            if fileManager.fileExists(atPath: path) {
+                result.insert(model.id)
+            }
+        }
+        return result
+    }
+
+    /// Returns true if the FluidAudio cache directory exists and contains any entries.
+    func isFluidModelDownloaded() -> Bool {
+        let dir = FluidTranscriptionService.cacheDirectory()
+        guard fileManager.fileExists(atPath: dir.path) else { return false }
+        let contents = (try? fileManager.contentsOfDirectory(atPath: dir.path)) ?? []
+        return !contents.isEmpty
+    }
+
+    /// Removes the on-disk files for a bundled Whisper model (no effect on user-imported catalog entries).
+    func deleteDownloadedBundledWhisperModel(id: String) throws {
+        guard let model = availableModels.first(where: { $0.id == id && !$0.id.hasPrefix("user-") }) else {
+            throw ModelDeletionError.modelNotFound(id)
+        }
+        guard let dir = modelsDirectory else {
+            throw ModelDeletionError.userModelsDirectoryUnavailable
+        }
+
+        for fileInfo in model.files {
+            let fileURL = dir.appendingPathComponent(fileInfo.filename)
+            if fileManager.fileExists(atPath: fileURL.path) {
+                do { try fileManager.removeItem(at: fileURL) }
+                catch { throw ModelDeletionError.fileRemovalFailed(path: fileURL.path, underlying: error) }
+            }
+            if fileInfo.type == "zip" {
+                let unzippedName = (fileInfo.filename as NSString).deletingPathExtension
+                let unzippedURL = dir.appendingPathComponent(unzippedName)
+                if fileManager.fileExists(atPath: unzippedURL.path) {
+                    try? fileManager.removeItem(at: unzippedURL)
+                }
+            }
+        }
+
+        if selectedModelID == id {
+            WhisperTranscriptionService.reinitializeContext()
+        }
+        NotificationCenter.default.post(name: .modelManagerDidUpdate, object: self)
+    }
+
+    /// Removes the FluidAudio model cache directory. The model will re-download on next use.
+    func deleteDownloadedFluidModel() throws {
+        let dir = FluidTranscriptionService.cacheDirectory()
+        guard fileManager.fileExists(atPath: dir.path) else { return }
+        do { try fileManager.removeItem(at: dir) }
+        catch { throw ModelDeletionError.fileRemovalFailed(path: dir.path, underlying: error) }
+        NotificationCenter.default.post(name: .modelManagerDidUpdate, object: self)
     }
 
     // MARK: - Model Preparation (Checking & Downloading) - To be implemented

--- a/WhisperServer/ModelManager.swift
+++ b/WhisperServer/ModelManager.swift
@@ -507,14 +507,28 @@ final class ModelManager: @unchecked Sendable {
 
     // MARK: - Downloaded Model Inspection & Deletion
 
-    /// Returns the IDs of bundled Whisper models whose primary .bin file is present on disk.
+    /// Returns the IDs of bundled Whisper models that have any associated on-disk artifact.
+    /// Includes unzipped directories for `.zip` entries so orphaned caches (e.g. the
+    /// encoder bundle left behind after a partial download) are still discoverable
+    /// from "Delete Downloaded Models".
     func downloadedBundledWhisperModelIDs() -> Set<String> {
         guard let dir = modelsDirectory else { return [] }
         var result: Set<String> = []
         for model in availableModels where !model.id.hasPrefix("user-") {
-            guard let binFile = model.files.first(where: { $0.type == "bin" }) else { continue }
-            let path = dir.appendingPathComponent(binFile.filename).path
-            if fileManager.fileExists(atPath: path) {
+            let hasAnyArtifact = model.files.contains { fileInfo in
+                let fileURL = dir.appendingPathComponent(fileInfo.filename)
+                if fileManager.fileExists(atPath: fileURL.path) { return true }
+
+                if fileInfo.type == "zip" {
+                    let unzippedName = (fileInfo.filename as NSString).deletingPathExtension
+                    let unzippedURL = dir.appendingPathComponent(unzippedName)
+                    if fileManager.fileExists(atPath: unzippedURL.path) { return true }
+                }
+
+                return false
+            }
+
+            if hasAnyArtifact {
                 result.insert(model.id)
             }
         }

--- a/WhisperServer/SettingsStore.swift
+++ b/WhisperServer/SettingsStore.swift
@@ -39,6 +39,14 @@ final class SettingsStore: ObservableObject {
         didSet { UserDefaults.standard.set(requireAPIKey, forKey: Keys.requireAPIKey) }
     }
 
+    /// Thread-safe snapshot of the `requireAPIKey` flag for readers outside the
+    /// main actor (e.g. Vapor middleware on NIO event loops). `UserDefaults` is
+    /// documented as thread-safe, and `didSet` above writes to it before any
+    /// @Published observer fires — so there's no window where the value drifts.
+    static var isAPIKeyRequired: Bool {
+        UserDefaults.standard.bool(forKey: Keys.requireAPIKey)
+    }
+
     var lanWarningShown: Bool {
         get { UserDefaults.standard.bool(forKey: Keys.lanWarningShown) }
         set { UserDefaults.standard.set(newValue, forKey: Keys.lanWarningShown) }

--- a/WhisperServer/SettingsStore.swift
+++ b/WhisperServer/SettingsStore.swift
@@ -1,0 +1,140 @@
+//
+//  SettingsStore.swift
+//  WhisperServer
+//
+//  Persistent user preferences (launch at login, LAN exposure)
+//
+
+import Foundation
+import ServiceManagement
+import Darwin
+
+/// Source of truth for WhisperServer user preferences.
+final class SettingsStore: ObservableObject {
+    static let shared = SettingsStore()
+
+    private enum Keys {
+        static let launchAtLogin = "launchAtLogin"
+        static let exposeOnLAN = "exposeOnLAN"
+        static let lanWarningShown = "lanWarningShown"
+        static let requireAPIKey = "requireAPIKey"
+        static let apiKeyWarningShown = "apiKeyWarningShown"
+    }
+
+    // MARK: - Stored Settings
+
+    @Published var launchAtLogin: Bool {
+        didSet {
+            UserDefaults.standard.set(launchAtLogin, forKey: Keys.launchAtLogin)
+            guard !isSyncing else { return }
+            applyLaunchAtLogin()
+        }
+    }
+
+    @Published var exposeOnLAN: Bool {
+        didSet { UserDefaults.standard.set(exposeOnLAN, forKey: Keys.exposeOnLAN) }
+    }
+
+    @Published var requireAPIKey: Bool {
+        didSet { UserDefaults.standard.set(requireAPIKey, forKey: Keys.requireAPIKey) }
+    }
+
+    var lanWarningShown: Bool {
+        get { UserDefaults.standard.bool(forKey: Keys.lanWarningShown) }
+        set { UserDefaults.standard.set(newValue, forKey: Keys.lanWarningShown) }
+    }
+
+    var apiKeyWarningShown: Bool {
+        get { UserDefaults.standard.bool(forKey: Keys.apiKeyWarningShown) }
+        set { UserDefaults.standard.set(newValue, forKey: Keys.apiKeyWarningShown) }
+    }
+
+    // MARK: - Derived Values
+
+    /// Hostname to bind the HTTP server on.
+    var serverHostname: String { exposeOnLAN ? "0.0.0.0" : "localhost" }
+
+    // MARK: - Private
+
+    /// Suppresses side effects while we sync published values from the system.
+    private var isSyncing = false
+
+    private init() {
+        self.launchAtLogin = UserDefaults.standard.bool(forKey: Keys.launchAtLogin)
+        self.exposeOnLAN = UserDefaults.standard.bool(forKey: Keys.exposeOnLAN)
+        self.requireAPIKey = UserDefaults.standard.bool(forKey: Keys.requireAPIKey)
+        syncLaunchAtLoginFromSystem()
+    }
+
+    /// Registers or unregisters the main app as a login item via SMAppService.
+    private func applyLaunchAtLogin() {
+        let service = SMAppService.mainApp
+        do {
+            if launchAtLogin {
+                if service.status != .enabled { try service.register() }
+            } else {
+                if service.status == .enabled { try service.unregister() }
+            }
+        } catch {
+            print("❌ Failed to toggle launch-at-login: \(error.localizedDescription)")
+            DispatchQueue.main.async { [weak self] in
+                guard let self else { return }
+                self.isSyncing = true
+                self.launchAtLogin = (SMAppService.mainApp.status == .enabled)
+                self.isSyncing = false
+            }
+        }
+    }
+
+    /// Reconciles our cached state with the system's actual SMAppService status
+    /// (the user may have toggled the login item via System Settings).
+    private func syncLaunchAtLoginFromSystem() {
+        let systemEnabled = (SMAppService.mainApp.status == .enabled)
+        if launchAtLogin != systemEnabled {
+            isSyncing = true
+            launchAtLogin = systemEnabled
+            isSyncing = false
+        }
+    }
+}
+
+// MARK: - Network Utility
+
+enum NetworkUtility {
+    /// Returns the machine's primary non-loopback IPv4 address (prefers en0/en1).
+    static func primaryLocalIPv4() -> String? {
+        var ifaddrPtr: UnsafeMutablePointer<ifaddrs>?
+        guard getifaddrs(&ifaddrPtr) == 0, let first = ifaddrPtr else { return nil }
+        defer { freeifaddrs(ifaddrPtr) }
+
+        var fallback: String?
+        var iter: UnsafeMutablePointer<ifaddrs>? = first
+        while let ptr = iter {
+            defer { iter = ptr.pointee.ifa_next }
+
+            let flags = Int32(ptr.pointee.ifa_flags)
+            guard (flags & IFF_UP) != 0,
+                  (flags & IFF_LOOPBACK) == 0,
+                  let addr = ptr.pointee.ifa_addr,
+                  addr.pointee.sa_family == UInt8(AF_INET) else { continue }
+
+            var host = [CChar](repeating: 0, count: Int(NI_MAXHOST))
+            let result = getnameinfo(
+                addr,
+                socklen_t(addr.pointee.sa_len),
+                &host,
+                socklen_t(host.count),
+                nil,
+                0,
+                NI_NUMERICHOST
+            )
+            guard result == 0 else { continue }
+
+            let ip = String(cString: host)
+            let name = String(cString: ptr.pointee.ifa_name)
+            if name == "en0" || name == "en1" { return ip }
+            if fallback == nil { fallback = ip }
+        }
+        return fallback
+    }
+}

--- a/WhisperServer/VaporServer.swift
+++ b/WhisperServer/VaporServer.swift
@@ -88,7 +88,15 @@ final class VaporServer {
             try app.start()
             DispatchQueue.main.async {
                 self.isRunning = true
-                print("✅ Vapor server started on http://\(hostname):\(self.port)")
+                if hostname == "0.0.0.0" {
+                    if let lanIP = NetworkUtility.primaryLocalIPv4() {
+                        print("✅ Vapor server listening on 0.0.0.0:\(self.port) — reachable at http://\(lanIP):\(self.port)")
+                    } else {
+                        print("✅ Vapor server listening on 0.0.0.0:\(self.port)")
+                    }
+                } else {
+                    print("✅ Vapor server started on http://\(hostname):\(self.port)")
+                }
             }
         } catch {
             print("❌ Failed to start Vapor server: \(error)")

--- a/WhisperServer/VaporServer.swift
+++ b/WhisperServer/VaporServer.swift
@@ -74,8 +74,12 @@ final class VaporServer {
             self.app = app
 
             // Configure the server
-            app.http.server.configuration.hostname = "localhost"
+            let hostname = SettingsStore.shared.serverHostname
+            app.http.server.configuration.hostname = hostname
             app.http.server.configuration.port = port
+
+            // Authenticate LAN clients when required; loopback is always allowed through.
+            app.middleware.use(APIKeyAuthMiddleware())
 
             // Register routes
             try routes(app)
@@ -84,7 +88,7 @@ final class VaporServer {
             try app.start()
             DispatchQueue.main.async {
                 self.isRunning = true
-                print("✅ Vapor server started on http://localhost:\(self.port)")
+                print("✅ Vapor server started on http://\(hostname):\(self.port)")
             }
         } catch {
             print("❌ Failed to start Vapor server: \(error)")

--- a/test_api_lan.sh
+++ b/test_api_lan.sh
@@ -1,0 +1,302 @@
+#!/bin/bash
+
+# WhisperServer LAN + API key middleware tests.
+# Standalone, does not source test_api.sh.
+#
+# What this script does:
+#   1. Detects the Mac's primary LAN IPv4 address.
+#   2. Probes http://<LAN-IP>:12017/v1/models without a token to classify mode:
+#        - unreachable  → "Expose on Local Network" is off → stops with a hint.
+#        - 200          → auth is disabled, runs the "open LAN" subset.
+#        - 401          → auth is required, runs the "locked LAN" subset.
+#   3. Always re-verifies that loopback (127.0.0.1) bypasses auth regardless of mode.
+#
+# Prerequisites:
+#   - The app is running.
+#   - "Expose on Local Network" is enabled from the menu bar.
+#   - jfk.wav is present next to this script (same layout as test_api.sh).
+#   - When "Require API Key" is on, pass the token via WHISPER_API_KEY=ws-...
+#     (Menu → Copy API Key).
+
+set -euo pipefail
+
+SERVER_URL="http://localhost:12017"
+PORT="12017"
+TEST_AUDIO="jfk.wav"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m'
+
+TEST_FAILURES=0
+LAST_BODY=""
+LAST_STATUS=""
+CURL_ERROR=""
+
+record_pass() {
+    printf "%b✅ PASS:%b %s\n" "$GREEN" "$NC" "$1"
+}
+
+record_fail() {
+    TEST_FAILURES=1
+    printf "%b❌ FAIL:%b %s\n" "$RED" "$NC" "$1"
+    if [ $# -gt 1 ] && [ -n "${2:-}" ]; then
+        printf "   %s\n" "$2"
+    fi
+}
+
+render_command() {
+    local cmd="curl"
+    for arg in "$@"; do
+        cmd+=" \"${arg//\"/\\\"}\""
+    done
+    printf '%s' "$cmd"
+}
+
+run_curl() {
+    set +e
+    local response
+    response=$(curl -sS -w '\n%{http_code}' "$@" 2>&1)
+    local exit_code=$?
+    set -e
+    if [ $exit_code -ne 0 ]; then
+        CURL_ERROR="$response"
+        LAST_BODY=""
+        LAST_STATUS=""
+        return 1
+    fi
+    LAST_STATUS="${response##*$'\n'}"
+    LAST_BODY="${response%$'\n'$LAST_STATUS}"
+    CURL_ERROR=""
+    return 0
+}
+
+# --- Lightweight validators -------------------------------------------------
+
+validate_model_list() {
+    BODY="$LAST_BODY" python3 - <<'PY'
+import json, os, sys
+body = os.environ.get("BODY", "")
+try:
+    data = json.loads(body)
+except Exception as exc:  # noqa: BLE001
+    print(f"JSON decode failed: {exc}", file=sys.stderr)
+    sys.exit(1)
+if data.get("object") != "list":
+    print("Root object must be 'list'", file=sys.stderr)
+    sys.exit(1)
+items = data.get("data")
+if not isinstance(items, list) or not items:
+    print("'data' must be a non-empty array", file=sys.stderr)
+    sys.exit(1)
+sys.exit(0)
+PY
+}
+
+validate_json_text() {
+    BODY="$LAST_BODY" python3 - <<'PY'
+import json, os, sys
+body = os.environ.get("BODY", "")
+try:
+    data = json.loads(body)
+except Exception as exc:  # noqa: BLE001
+    print(f"JSON decode failed: {exc}", file=sys.stderr)
+    sys.exit(1)
+text = data.get("text")
+if not isinstance(text, str) or not text.strip():
+    print("'text' field missing or empty", file=sys.stderr)
+    sys.exit(1)
+sys.exit(0)
+PY
+}
+
+validate_json_error() {
+    BODY="$LAST_BODY" python3 - <<'PY'
+import json, os, sys
+body = os.environ.get("BODY", "")
+try:
+    data = json.loads(body)
+except Exception as exc:  # noqa: BLE001
+    print(f"Error JSON decode failed: {exc}", file=sys.stderr)
+    sys.exit(1)
+err = data.get("error")
+reason = data.get("reason")
+if isinstance(err, str) and err.strip():
+    sys.exit(0)
+if isinstance(err, bool) and err:
+    if isinstance(reason, str) and reason.strip():
+        sys.exit(0)
+    print("Error response missing non-empty 'reason'", file=sys.stderr)
+    sys.exit(1)
+print("Error response missing 'error' field", file=sys.stderr)
+sys.exit(1)
+PY
+}
+
+# --- Runner -----------------------------------------------------------------
+
+run_http_test() {
+    local name="$1"
+    local expected_status="$2"
+    local validator="$3"
+    shift 3
+    local command
+    command=$(render_command "$@")
+    printf "%b🧪 %s%b\n" "$BLUE" "$name" "$NC"
+    printf "%b   %s%b\n" "$YELLOW" "$command" "$NC"
+    if ! run_curl "$@"; then
+        record_fail "$name" "curl failed: $CURL_ERROR"
+        echo ""
+        return
+    fi
+    if [ "$LAST_STATUS" != "$expected_status" ]; then
+        record_fail "$name" "Expected HTTP $expected_status, got $LAST_STATUS"
+        [ -n "$LAST_BODY" ] && printf "   Body: %s\n" "$LAST_BODY"
+        echo ""
+        return
+    fi
+    if ! $validator; then
+        record_fail "$name" "Body validation failed"
+        [ -n "$LAST_BODY" ] && printf "   Body: %s\n" "$LAST_BODY"
+        echo ""
+        return
+    fi
+    record_pass "$name"
+    echo ""
+}
+
+# --- LAN discovery ----------------------------------------------------------
+
+detect_lan_ip() {
+    local ip
+    for iface in en0 en1 en2 en3 en4 en5; do
+        ip=$(ipconfig getifaddr "$iface" 2>/dev/null || true)
+        if [ -n "$ip" ]; then
+            printf '%s' "$ip"
+            return 0
+        fi
+    done
+    return 1
+}
+
+probe_status() {
+    local url="$1"
+    set +e
+    local code
+    code=$(curl -sS --connect-timeout 3 -o /dev/null -w '%{http_code}' "$url" 2>/dev/null)
+    local exit_code=$?
+    set -e
+    if [ $exit_code -ne 0 ]; then
+        printf 'unreachable'
+        return
+    fi
+    printf '%s' "$code"
+}
+
+# --- Preflight --------------------------------------------------------------
+
+preflight() {
+    if [ ! -f "$TEST_AUDIO" ]; then
+        printf "%b❌ Test audio '%s' not found next to this script.%b\n" "$RED" "$TEST_AUDIO" "$NC"
+        printf "   Download with: curl -O https://github.com/openai/whisper/raw/main/tests/jfk.wav\n"
+        exit 1
+    fi
+
+    printf "%b🔍 Checking server on %s...%b\n" "$YELLOW" "$SERVER_URL" "$NC"
+    if ! curl -s --connect-timeout 5 "$SERVER_URL/v1/models" > /dev/null 2>&1; then
+        printf "%b❌ Server not responding on %s — start the app first.%b\n" "$RED" "$SERVER_URL" "$NC"
+        exit 1
+    fi
+    printf "%b✅ Server responding%b\n\n" "$GREEN" "$NC"
+}
+
+# --- Main -------------------------------------------------------------------
+
+main() {
+    printf "%b============================================%b\n" "$BLUE" "$NC"
+    printf "%b🌐 WhisperServer LAN + API Key test suite%b\n" "$BLUE" "$NC"
+    printf "%b============================================%b\n\n" "$BLUE" "$NC"
+
+    preflight
+
+    local lan_ip
+    if ! lan_ip=$(detect_lan_ip); then
+        printf "%b⚠️  No LAN interface with IPv4 detected (en0..en5).%b\n" "$YELLOW" "$NC"
+        printf "   Connect to a network and retry.\n"
+        exit 0
+    fi
+
+    local lan_url="http://${lan_ip}:${PORT}"
+    printf "%b🔍 LAN endpoint: %s%b\n" "$YELLOW" "$lan_url" "$NC"
+
+    local probe
+    probe=$(probe_status "$lan_url/v1/models")
+
+    if [ "$probe" = "unreachable" ]; then
+        printf "%b⚠️  %s is unreachable — 'Expose on Local Network' appears to be off.%b\n" "$YELLOW" "$lan_url" "$NC"
+        printf "   Enable it from the menu bar and re-run.\n"
+        exit 0
+    fi
+
+    # Loopback should always bypass auth — critical regression check.
+    printf "\n%b── Loopback bypass ──%b\n" "$BLUE" "$NC"
+    run_http_test "Loopback GET without header → 200" 200 validate_model_list \
+        -X GET "$SERVER_URL/v1/models"
+    run_http_test "Loopback GET with bogus header → 200" 200 validate_model_list \
+        -H "Authorization: Bearer ws-ignored-on-loopback" \
+        -X GET "$SERVER_URL/v1/models"
+
+    case "$probe" in
+        200)
+            printf "\n%b── LAN, auth OFF ──%b\n" "$GREEN" "$NC"
+            run_http_test "LAN GET without header → 200" 200 validate_model_list \
+                -X GET "$lan_url/v1/models"
+            run_http_test "LAN GET with ignored header → 200" 200 validate_model_list \
+                -H "Authorization: Bearer ws-anything" \
+                -X GET "$lan_url/v1/models"
+            run_http_test "LAN POST transcription without header → 200" 200 validate_json_text \
+                -X POST "$lan_url/v1/audio/transcriptions" \
+                -F "file=@$TEST_AUDIO" \
+                -F "response_format=json"
+            ;;
+        401)
+            printf "\n%b── LAN, auth REQUIRED ──%b\n" "$YELLOW" "$NC"
+            run_http_test "LAN GET without header → 401" 401 validate_json_error \
+                -X GET "$lan_url/v1/models"
+            run_http_test "LAN GET with wrong token → 401" 401 validate_json_error \
+                -H "Authorization: Bearer ws-definitely-wrong" \
+                -X GET "$lan_url/v1/models"
+
+            if [ -n "${WHISPER_API_KEY:-}" ]; then
+                run_http_test "LAN GET with valid token → 200" 200 validate_model_list \
+                    -H "Authorization: Bearer $WHISPER_API_KEY" \
+                    -X GET "$lan_url/v1/models"
+                run_http_test "LAN POST transcription with valid token → 200" 200 validate_json_text \
+                    -H "Authorization: Bearer $WHISPER_API_KEY" \
+                    -X POST "$lan_url/v1/audio/transcriptions" \
+                    -F "file=@$TEST_AUDIO" \
+                    -F "response_format=json"
+            else
+                printf "%b⚠️  WHISPER_API_KEY not set — skipping valid-token cases.%b\n" "$YELLOW" "$NC"
+                printf "   Copy the key from the menu bar (Copy API Key) and re-run:\n"
+                printf "     WHISPER_API_KEY=ws-... ./test_api_lan.sh\n\n"
+            fi
+            ;;
+        *)
+            record_fail "LAN probe" "Unexpected status '$probe' from $lan_url/v1/models"
+            ;;
+    esac
+
+    printf "%b============================================%b\n" "$BLUE" "$NC"
+    if [ $TEST_FAILURES -eq 0 ]; then
+        printf "%b🎉 LAN test suite passed%b\n" "$GREEN" "$NC"
+        exit 0
+    else
+        printf "%b⚠️  LAN test suite had failures%b\n" "$YELLOW" "$NC"
+        exit 1
+    fi
+}
+
+main "$@"

--- a/test_api_lan.sh
+++ b/test_api_lan.sh
@@ -20,9 +20,11 @@
 
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
 SERVER_URL="http://localhost:12017"
 PORT="12017"
-TEST_AUDIO="jfk.wav"
+TEST_AUDIO="$SCRIPT_DIR/jfk.wav"
 
 RED='\033[0;31m'
 GREEN='\033[0;32m'


### PR DESCRIPTION
## Summary

Adds a **Preferences ▸** submenu in the menu bar with three user-visible toggles and a new model-management flow. Top-level menu is flattened to `Server → Select Model → Preferences → Quit`.

## Why?

- We can allow using whisper server on a powerful machine for our agents (openclaw, hermes agent) on other low-tier pc
- We can more easily manage downloaded models

<img width="521" height="205" alt="Снимок экрана 2026-04-21 в 12 53 49" src="https://github.com/user-attachments/assets/a778cc51-40d5-40db-9905-cd43fce06f74" />
<img width="571" height="391" alt="Снимок экрана 2026-04-21 в 12 53 58" src="https://github.com/user-attachments/assets/71b9b0b4-9594-4294-a585-f3c46dc6f16f" />

### Preferences
- **Launch at Login** — via `SMAppService.mainApp`; initial state reconciled with the system on launch so the checkmark never lies if the user removes the login item from *System Settings → Login Items*.
- **Expose on Local Network** — binds the Vapor server to `0.0.0.0:12017` instead of `localhost`. Shows the LAN URL and a *Copy Server URL* action. First-time toggle shows a warning alert mentioning the macOS Application Firewall.
- **Require API Key** (nested under LAN) — optional bearer-token enforcement. First enable auto-generates a `ws-<64 hex>` token stored in Keychain (`kSecClassGenericPassword`). *Copy API Key* and *Regenerate API Key…* (with confirmation) become available. Loopback clients (127.0.0.1 / ::1) **always** bypass auth so local tooling (e.g. `test_api.sh`) keeps working without any changes.

### Model management
- `Select Model → Delete Downloaded Models ▸`: *Show in Finder* (opens the models directory) plus per-model trash actions for downloaded bundled Whisper + FluidAudio caches. User-imported models keep their existing Option-click delete.
- The `#if DEBUG` *Reset Application Data* action moved from the top level into the Preferences submenu.

### Implementation notes
- `SettingsStore` — UserDefaults-backed `ObservableObject` with three @Published bools. Launch-at-login changes trigger `SMAppService.register/unregister`; errors roll back the published value so the UI doesn't lie.
- `APIKeyStore` — Keychain wrapper (`ensureExists`/`current`/`regenerate`). `APIKeyAuthMiddleware` — Vapor `AsyncMiddleware`, constant-time compare, loopback detection via `request.remoteAddress` (handles `::ffff:127.0.0.1` too).
- `ModelManager` gains `modelsDirectoryURL`, `downloadedBundledWhisperModelIDs()`, `isFluidModelDownloaded()`, `deleteDownloadedBundledWhisperModel(id:)`, `deleteDownloadedFluidModel()`.
- `VaporServer.start()` reads hostname from `SettingsStore.shared.serverHostname` and installs `APIKeyAuthMiddleware` unconditionally (mode is driven by settings + loopback bypass; regenerating the key takes effect without a restart).

### Docs
- `README.md` — new Preferences section covering LAN URL, API key header format, firewall prompt, clipboard UX.
- `AGENTS.md` — updated Security & Configuration notes with `SettingsStore` / `APIKeyStore` / `APIKeyAuthMiddleware` references and the loopback-bypass rule.

### Tests
- Existing `test_api.sh` is **untouched** — it continues to work because loopback always bypasses the middleware.
- New **standalone** `test_api_lan.sh` probes the LAN IP to classify the middleware mode, asserts loopback bypass, and runs the appropriate auth-off or auth-on subset. Valid-token cases read `WHISPER_API_KEY=ws-...` from env.

## Test plan

- [x] \`xcodebuild -project WhisperServer.xcodeproj -scheme WhisperServer -configuration Debug build\` — ✅ succeeded. Warnings are all in the pre-existing \`VaporServer\` FluidAudio streaming block, not introduced by this PR.
- [ ] \`./test_api.sh\` from localhost — still passes unchanged, regardless of toggle states (loopback bypass).
- [ ] \`./test_api_lan.sh\` — auth-off mode: 200 OK to LAN endpoint with and without header.
- [ ] \`WHISPER_API_KEY=ws-... ./test_api_lan.sh\` — auth-on mode: 401 without/wrong token, 200 with valid token (GET + POST transcription).
- [ ] *Launch at Login* — toggle on, verify in *System Settings → General → Login Items*; toggle off, verify removed. Relogin → app starts automatically.
- [ ] *Expose on Local Network* — first-time alert shown; macOS Firewall prompt acknowledged on first incoming LAN connection; *Copy Server URL* copies the right URL.
- [ ] *Require API Key* — first-time alert shows the generated key; *Copy API Key* and *Regenerate API Key…* (with confirmation) work; old key stops working after regenerate.
- [ ] *Select Model → Delete Downloaded Models* — *Show in Finder* opens the right folder; per-model delete removes files; submenu refreshes to reflect the remaining downloads; deleted model re-downloads on next use.

_Screenshots of the reorganized menu to be added in a follow-up comment._