### PR TITLE
Bump marketing version to 2.7.0 (build 9)

### DIFF
--- a/WhisperServer.xcodeproj/project.pbxproj
+++ b/WhisperServer.xcodeproj/project.pbxproj
@@ -455,7 +455,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 14.6;
-				MARKETING_VERSION = 2.6.0;
+				MARKETING_VERSION = 2.7.0;
 				PRODUCT_BUNDLE_IDENTIFIER = pfrankov.WhisperServer;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -488,7 +488,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 14.6;
-				MARKETING_VERSION = 2.6.0;
+				MARKETING_VERSION = 2.7.0;
 				PRODUCT_BUNDLE_IDENTIFIER = pfrankov.WhisperServer;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/WhisperServer/Info.plist
+++ b/WhisperServer/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
-	<string>8</string>
+	<string>9</string>
 	<key>LSUIElement</key>
 	<true/>
 	<key>NSAppTransportSecurity</key>


### PR DESCRIPTION
Pre-release version bump for 2.7.0. Mirrors the 2.6.0 bump (3405aae) — two files, app target only, test targets stay at 1.0.

## Changes since 2.6.0 worth highlighting in the GitHub release

- **Preferences menu** (#4): autostart, LAN exposure toggle, API key authentication, and in-app model download/switching.
- Tuned `DiarizerManager` settings for speaker separation and segment duration (67d3d27).
- Updated FluidAudio to 0.7.4 (130f367).
- Refreshed stale-issue workflow (a04e73c, 6e3d549) and testing guide (4806a1a).

After merge, please tag `2.7.0` on main, archive/notarize the .app, and publish the GitHub release. Happy to follow up with a `release.yml` GitHub Action in a separate PR so future tag pushes auto-build and publish.