### PR TITLE
Fix use-after-free when inactivity timer frees Whisper context mid-inference

### DIFF
--- a/WhisperServer.xcodeproj/project.pbxproj
+++ b/WhisperServer.xcodeproj/project.pbxproj
@@ -455,7 +455,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 14.6;
-				MARKETING_VERSION = 2.6.0;
+				MARKETING_VERSION = 2.8.0;
 				PRODUCT_BUNDLE_IDENTIFIER = pfrankov.WhisperServer;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -488,7 +488,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 14.6;
-				MARKETING_VERSION = 2.6.0;
+				MARKETING_VERSION = 2.8.0;
 				PRODUCT_BUNDLE_IDENTIFIER = pfrankov.WhisperServer;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/WhisperServer/Info.plist
+++ b/WhisperServer/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
-	<string>8</string>
+	<string>9</string>
 	<key>LSUIElement</key>
 	<true/>
 	<key>NSAppTransportSecurity</key>

--- a/WhisperServer/WhisperContextManager.swift
+++ b/WhisperServer/WhisperContextManager.swift
@@ -10,6 +10,15 @@ class WhisperContextManager {
     /// Shared context and lock for thread-safe access
     private static var sharedContext: OpaquePointer?
     private static let lock = NSLock()
+
+    /// Number of transcription operations currently using the shared context.
+    /// While non-zero the shared context must never be freed: whisper_full may
+    /// still be running on it outside the lock.
+    private static var activeUseCount = 0
+
+    /// Set when a free was requested (inactivity timeout or model switch) while
+    /// the context was in use; the free is performed by the last releaseContext().
+    private static var pendingFree = false
     private static let logQueue = DispatchQueue(label: "com.whisperserver.whisper.log", qos: .utility)
     private static var isLoggingConfigured = false
 
@@ -54,15 +63,54 @@ class WhisperContextManager {
     private static func checkAndReleaseResources() {
         let currentTime = Date()
         let elapsedTime = currentTime.timeIntervalSince(lastActivityTime)
-        
+
         if elapsedTime >= inactivityTimeout {
             lock.lock(); defer { lock.unlock() }
 
-            if let ctx = sharedContext {
-                whisper_free(ctx)
-                sharedContext = nil
-            }
+            // A transcription is still running on the context; freeing it now
+            // would be a use-after-free. releaseContext() restarts the timer.
+            guard activeUseCount == 0 else { return }
+
+            freeSharedContextUnsafe()
         }
+    }
+
+    /// Frees the shared context. This function MUST be called from within the lock.
+    private static func freeSharedContextUnsafe() {
+        if let ctx = sharedContext {
+            whisper_free(ctx)
+            sharedContext = nil
+        }
+    }
+
+    /// Acquires the shared context for a transcription operation and marks it as
+    /// in use so it cannot be freed until the matching releaseContext() call.
+    /// - Parameter modelPaths: The paths to the model files.
+    /// - Returns: An `OpaquePointer` to the Whisper context, or `nil` on failure.
+    static func acquireContext(modelPaths: (binPath: URL, encoderDir: URL)?) -> OpaquePointer? {
+        lock.lock(); defer { lock.unlock() }
+
+        resetInactivityTimer()
+
+        guard let context = getOrCreateContextUnsafe(modelPaths: modelPaths) else {
+            return nil
+        }
+        activeUseCount += 1
+        return context
+    }
+
+    /// Releases a context previously obtained via acquireContext(). Performs any
+    /// free that was deferred while the context was in use and restarts the
+    /// inactivity countdown from the end of the operation.
+    static func releaseContext() {
+        lock.lock(); defer { lock.unlock() }
+
+        activeUseCount = max(0, activeUseCount - 1)
+        if activeUseCount == 0 && pendingFree {
+            pendingFree = false
+            freeSharedContextUnsafe()
+        }
+        resetInactivityTimer()
     }
     
     /// Configures a persistent Metal shader cache
@@ -115,10 +163,12 @@ class WhisperContextManager {
     static func reinitializeContext() {
         lock.lock(); defer { lock.unlock() }
 
-        // First, free the current context if it exists
-        if let ctx = sharedContext {
-            whisper_free(ctx)
-            sharedContext = nil
+        // Free the current context, or defer the free if a transcription is
+        // still running on it (the last releaseContext() will perform it).
+        if activeUseCount > 0 {
+            pendingFree = true
+        } else {
+            freeSharedContextUnsafe()
         }
 
         // The context will be re-initialized on the next call to getOrCreateContext

--- a/WhisperServer/WhisperTranscriptionService.swift
+++ b/WhisperServer/WhisperTranscriptionService.swift
@@ -456,22 +456,25 @@ struct WhisperTranscriptionService {
                                        prompt: String?,
                                        modelPaths: (binPath: URL, encoderDir: URL)?) -> String? {
 
-        // Get context for this chunk
+        // Get context for this chunk. The shared context is acquired (not just
+        // fetched) so the inactivity timer cannot free it mid-inference.
         let context: OpaquePointer?
         if resetContextBetweenChunks {
             context = WhisperContextManager.createIsolatedContext(modelPaths: modelPaths)
         } else {
-            context = WhisperContextManager.getOrCreateContext(modelPaths: modelPaths)
+            context = WhisperContextManager.acquireContext(modelPaths: modelPaths)
         }
         guard let ctx = context else { return nil }
-        
+
         defer {
-            // Clean up isolated context
-            if resetContextBetweenChunks, let ctx = context {
+            if resetContextBetweenChunks {
+                // Clean up isolated context
                 whisper_free(ctx)
+            } else {
+                WhisperContextManager.releaseContext()
             }
         }
-        
+
         // Configure parameters
         var (params, langPtr, promptPtr) = makeWhisperParams(printTimestamps: false, language: language, prompt: prompt)
 
@@ -512,22 +515,25 @@ struct WhisperTranscriptionService {
                                                  prompt: String?, 
                                                  modelPaths: (binPath: URL, encoderDir: URL)?) -> [TranscriptionSegment]? {
         
-        // Get context for this chunk
+        // Get context for this chunk. The shared context is acquired (not just
+        // fetched) so the inactivity timer cannot free it mid-inference.
         let context: OpaquePointer?
         if resetContextBetweenChunks {
             context = WhisperContextManager.createIsolatedContext(modelPaths: modelPaths)
         } else {
-            context = WhisperContextManager.getOrCreateContext(modelPaths: modelPaths)
+            context = WhisperContextManager.acquireContext(modelPaths: modelPaths)
         }
         guard let ctx = context else { return nil }
-        
+
         defer {
-            // Clean up isolated context
-            if resetContextBetweenChunks, let ctx = context {
+            if resetContextBetweenChunks {
+                // Clean up isolated context
                 whisper_free(ctx)
+            } else {
+                WhisperContextManager.releaseContext()
             }
         }
-        
+
         // Configure parameters
         var (params, langPtr, promptPtr) = makeWhisperParams(printTimestamps: true, language: language, prompt: prompt)
 


### PR DESCRIPTION
## Problem

The server segfaults during long transcriptions. The inactivity timer (`WhisperContextManager`, 30 s default) frees the shared whisper context under the lock, but `whisper_full` runs on that context **outside** the lock for tens of seconds. The timer is only reset when a chunk *starts*, so whenever a single chunk's inference outlives the timeout — easy to hit with long continuous speech, which produces large VAD chunks — the context is freed mid-inference and the process crashes.

`reinitializeContext()` has the same defect: switching models while a transcription is running frees the context that inference is still using.

## Reproduction

Transcribing a 2-hour Russian podcast episode in 20-minute WAV chunks (`response_format=verbose_json`, `language=ru`, with a prompt) against v2.7.0: the server crashed on the second chunk, and repeatedly crashed on other days' runs (matching `WhisperServer_*.diag` reports in `/Library/Logs/DiagnosticReports`).

## Fix

Track in-flight use of the shared context with a use counter:

- `acquireContext()` / `releaseContext()` bracket every chunk transcription in `WhisperTranscriptionService`.
- The inactivity timer skips the free while `activeUseCount > 0`; `releaseContext()` restarts the countdown from the **end** of the operation.
- `reinitializeContext()` defers the free to the last `releaseContext()` (`pendingFree`) instead of freeing a context that may still be running inference.

The isolated-context path (`resetContextBetweenChunks`) is unchanged.

## Testing

- `xcodebuild build -project WhisperServer.xcodeproj -scheme WhisperServer` — builds clean.
- The exact chunk sequence that crashed v2.7.0 now completes (6 × 20-min chunks, verbose_json), including a 45 s idle window mid-run to confirm the timer still frees the context after genuine inactivity.
- `./test_api.sh` — all cases pass, including concurrent requests.
- A full multi-episode podcast transcription (~8.5 h of audio) is currently running against the patched build as an extended soak test; I'll report the result in a comment.